### PR TITLE
feat: add Roo Code agent support (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 ## Overview
 
-Imprint is a pattern for distributing AI Skills (those `SKILLS.md` files for GitHub Copilot, Claude, Cursor, and other AI assistants) and MCP Server configuration via NuGet packages. When you add an Imprint package to your project:
+Imprint is a pattern for distributing AI Skills (those `SKILLS.md` files for GitHub Copilot, Claude, Cursor, Roo Code, and other AI assistants) and MCP Server configuration via NuGet packages. When you add an Imprint package to your project:
 
 1. **On `dotnet build`**: Skills are automatically copied to each AI agent's native directory
 2. **On `dotnet clean`**: Skills are removed (including empty parent directories)
-3. **Multi-agent support**: Targets Copilot, Claude, and Cursor simultaneously — each gets files in its native location (if exists)
+3. **Multi-agent support**: Targets Copilot, Claude, Cursor, and Roo Code simultaneously — each gets files in its native location (if exists)
 4. **All file types supported**: Not just `.md` — scripts, configs, and any other files in the `skills/` folder are included
 5. **MCP Server Injection**: Packages can inject [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server configurations into each agent's `mcp.json`
 6. **Code + Skills**: Packages can ship both a compiled DLL library **and** AI skills — consumers get runtime APIs and AI guidance from a single NuGet install
@@ -56,10 +56,10 @@ dotnet add package <some-Imprint-package>
 # Build to install skills (happens automatically before build)
 dotnet build
 
-# Skills are now at .github/skills/, .claude/skills/, .cursor/rules/ etc.
+# Skills are now at .github/skills/, .claude/skills/, .cursor/rules/, .roo/rules/ etc.
 ```
 
-Imprint auto-detects which AI agents you use by scanning for their configuration directories (`.github/`, `.claude/`, `.cursor/`). Skills are copied to each detected agent's native location.
+Imprint auto-detects which AI agents you use by scanning for their configuration directories (`.github/`, `.claude/`, `.cursor/`, `.roo/`). Skills are copied to each detected agent's native location.
 
 A shared `.gitignore` is automatically generated at `.imprint/.gitignore`, so no manual `.gitignore` configuration is needed.
 
@@ -100,6 +100,7 @@ Imprint includes multi-agent support. Instead of targeting only GitHub Copilot, 
 | `copilot` | `.github/` exists | `.github/skills/` | `.vscode/mcp.json` | `servers` |
 | `claude` | `.claude/` exists | `.claude/skills/` | `.claude/mcp.json` | `mcpServers` |
 | `cursor` | `.cursor/` exists | `.cursor/rules/` | `.cursor/mcp.json` | `mcpServers` |
+| `roo` | `.roo/` exists | `.roo/rules/` | `.roo/mcp.json` | `mcpServers` |
 
 Unknown agent names fall back to `.{name}/skills/` for skills and `.{name}/mcp.json` for MCP.
 
@@ -115,6 +116,7 @@ Imprint determines which agents to target using a priority hierarchy:
    ```
 
 2. **Auto-detection** (default, ON) — Scans for agent directories at build time. If `.github/` and `.claude/` exist, both `copilot` and `claude` are targeted.
+   Supported detection directories: `.github/` (copilot), `.claude/` (claude), `.cursor/` (cursor), `.roo/` (roo).
 
 3. **Default fallback** — If no directories are detected:
    ```xml
@@ -187,7 +189,7 @@ All Imprint skill packages depend on **Zakira.Imprint.Sdk**, which provides the 
 
 2. **Agent Resolution**: Before any file operations, `AgentConfig.ResolveAgents()` determines which agents to target:
    - If `ImprintTargetAgents` is set, use that explicit list
-   - Else if `ImprintAutoDetectAgents` is true, scan for `.github/`, `.claude/`, `.cursor/` directories
+   - Else if `ImprintAutoDetectAgents` is true, scan for `.github/`, `.claude/`, `.cursor/`, `.roo/` directories
    - Else fall back to `ImprintDefaultAgents` (default: `copilot`)
 
 3. **Content Copy** (`Imprint_CopyContent`): For each resolved agent, copies skill files to the agent's native skills directory. Writes a unified manifest v2 at `.imprint/manifest.json` tracking all files per-agent per-package.
@@ -289,6 +291,7 @@ Different AI agents use different JSON schemas for their MCP configuration files
 | Copilot (VS Code) | `servers` | `{"servers": {"my-server": {...}}}` |
 | Claude | `mcpServers` | `{"mcpServers": {"my-server": {...}}}` |
 | Cursor | `mcpServers` | `{"mcpServers": {"my-server": {...}}}` |
+| Roo Code | `mcpServers` | `{"mcpServers": {"my-server": {...}}}` |
 
 **Package authors always write fragments using `"servers"`** as the root key. The SDK reads these fragments and transforms them to each agent's expected schema when writing to their respective `mcp.json` files. The inner server definition (`command`, `args`, `type`, `env`) is identical across all agents.
 
@@ -420,7 +423,7 @@ dotnet build
 - [x] ~~Per-package manifests for precise file tracking~~
 - [x] ~~Code + Skills package pattern~~
 - [x] ~~Unit tests for MSBuild task classes~~
-- [x] ~~Multi-agent support (Copilot, Claude, Cursor)~~
+- [x] ~~Multi-agent support (Copilot, Claude, Cursor, Roo Code)~~
 - [x] ~~Auto-detection of AI agents~~
 - [x] ~~Unified manifest v2 with per-agent tracking~~
 - [x] ~~Auto-generated `.targets` files — no manual MSBuild authoring required~~

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -10,20 +10,21 @@ permalink: /concepts/agents
 # Multi-Agent Support
 {: .fs-9 }
 
-Target GitHub Copilot, Claude, Cursor, and more - all at once.
+Target GitHub Copilot, Claude, Cursor, Roo Code, and more - all at once.
 {: .fs-6 .fw-300 }
 
 ---
 
 ## Supported Agents
 
-Imprint has built-in support for three AI assistants:
+Imprint has built-in support for four AI assistants:
 
 | Agent | Skills Directory | MCP Config File | MCP Root Key |
 |:------|:-----------------|:----------------|:-------------|
 | `copilot` | `.github/skills/` | `.vscode/mcp.json` | `servers` |
 | `claude` | `.claude/skills/` | `.claude/mcp.json` | `mcpServers` |
 | `cursor` | `.cursor/rules/` | `.cursor/mcp.json` | `mcpServers` |
+| `roo` | `.roo/rules/` | `.roo/mcp.json` | `mcpServers` |
 
 ### Agent-Specific Conventions
 
@@ -44,6 +45,11 @@ Each AI assistant has its own conventions:
 - MCP config in `.cursor/mcp.json`
 - Uses `mcpServers` as the root key in `mcp.json`
 
+**Roo Code**
+- Rules in `.roo/rules/` (note: "rules" not "skills")
+- MCP config in `.roo/mcp.json`
+- Uses `mcpServers` as the root key in `mcp.json`
+
 ---
 
 ## Agent Detection
@@ -55,6 +61,7 @@ Project Directory
 ├── .github/         ← Copilot detected
 ├── .claude/         ← Claude detected
 ├── .cursor/         ← Cursor detected
+├── .roo/            ← Roo Code detected
 └── MyProject.csproj
 ```
 
@@ -65,6 +72,7 @@ The detection logic checks for the existence of these directories:
 | `.github/` | `copilot` |
 | `.claude/` | `claude` |
 | `.cursor/` | `cursor` |
+| `.roo/` | `roo` |
 
 ---
 
@@ -211,6 +219,17 @@ skills/
 └── README.md
 ```
 
+**Installed to Roo Code (.roo/rules/):**
+```
+.roo/rules/
+├── authentication/
+│   └── SKILL.md
+├── security/
+│   ├── SKILL.md
+│   └── examples.md
+└── README.md
+```
+
 The same files are copied to each agent's native directory.
 
 ---
@@ -261,6 +280,9 @@ mkdir .claude
 
 # Enable Cursor detection
 mkdir .cursor
+
+# Enable Roo Code detection
+mkdir .roo
 ```
 
 Then run `dotnet build` - Imprint will detect and target those agents.

--- a/docs/concepts/manifest.md
+++ b/docs/concepts/manifest.md
@@ -218,6 +218,7 @@ If the manifest is deleted or corrupted, clean behavior changes:
 # .github/skills/
 # .claude/skills/
 # .cursor/rules/
+# .roo/rules/
 ```
 
 ---

--- a/docs/concepts/mcp-integration.md
+++ b/docs/concepts/mcp-integration.md
@@ -295,6 +295,22 @@ Different AI assistants use slightly different MCP formats:
 }
 ```
 
+### Roo Code
+
+**File:** `.roo/mcp.json`
+**Root Key:** `mcpServers`
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "npx",
+      "args": ["-y", "@org/server"]
+    }
+  }
+}
+```
+
 Imprint handles these differences automatically. You write one fragment with `servers`, and Imprint translates to the correct format for each agent.
 
 ---

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -17,11 +17,12 @@ Understanding the complete picture of Imprint's architecture.
 
 ## The Problem
 
-AI assistants like GitHub Copilot, Claude, and Cursor can be enhanced with context-specific instructions called "skills" or "rules". These are typically Markdown files placed in special directories:
+AI assistants like GitHub Copilot, Claude, Cursor, and Roo Code can be enhanced with context-specific instructions called "skills" or "rules". These are typically Markdown files placed in special directories:
 
 - GitHub Copilot: `.github/skills/`
 - Claude: `.claude/skills/`
 - Cursor: `.cursor/rules/`
+- Roo Code: `.roo/rules/`
 
 The challenge is: **how do you distribute these skills across an organization or to users of your library?**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ Create and consume AI skill packages in minutes.
 ## Prerequisites
 
 - [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
-- An AI assistant (GitHub Copilot, Claude, or Cursor)
+- An AI assistant (GitHub Copilot, Claude, Cursor, or Roo Code)
 
 ---
 
@@ -51,6 +51,9 @@ ls .claude/skills/
 
 # For Cursor users
 ls .cursor/rules/
+
+# For Roo Code users
+ls .roo/rules/
 ```
 
 That's it! Your AI assistant now has access to the skills from the package.
@@ -171,6 +174,7 @@ When you build a project with Imprint packages installed, several things happen:
 | `.github/skills/*` | Skills for GitHub Copilot |
 | `.claude/skills/*` | Skills for Claude |
 | `.cursor/rules/*` | Skills for Cursor |
+| `.roo/rules/*` | Skills for Roo Code |
 | `.imprint/manifest.json` | Tracks installed files for cleanup |
 | `.imprint/.gitignore` | Prevents manifest from being committed |
 
@@ -211,6 +215,7 @@ Imprint automatically detects which AI agents you're using by looking for their 
 | `.github/` | GitHub Copilot |
 | `.claude/` | Claude |
 | `.cursor/` | Cursor |
+| `.roo/` | Roo Code |
 
 If no agent directories are found, Imprint defaults to targeting GitHub Copilot.
 
@@ -243,7 +248,7 @@ Now that you have the basics:
 ### Skills Not Appearing
 
 1. **Check the build output** - Look for `Imprint_CopyContent` in the build logs
-2. **Verify agent directories exist** - Create `.github/`, `.claude/`, or `.cursor/` if needed
+2. **Verify agent directories exist** - Create `.github/`, `.claude/`, `.cursor/`, or `.roo/` if needed
 3. **Check the manifest** - Look at `.imprint/manifest.json` to see what was installed
 
 ### Package Not Working

--- a/docs/guides/consuming-packages.md
+++ b/docs/guides/consuming-packages.md
@@ -76,6 +76,9 @@ ls .claude/skills/
 
 # Cursor
 ls .cursor/rules/
+
+# Roo Code
+ls .roo/rules/
 ```
 
 ### Check MCP Configuration
@@ -89,6 +92,9 @@ cat .claude/mcp.json
 
 # Cursor
 cat .cursor/mcp.json
+
+# Roo Code
+cat .roo/mcp.json
 ```
 
 ### Check the Manifest
@@ -135,6 +141,7 @@ By default, Imprint detects agents by looking for their directories:
 | `.github/` | copilot |
 | `.claude/` | claude |
 | `.cursor/` | cursor |
+| `.roo/` | roo |
 
 To enable auto-detection, create the agent directory:
 
@@ -142,6 +149,7 @@ To enable auto-detection, create the agent directory:
 mkdir .github   # Enable Copilot
 mkdir .claude   # Enable Claude
 mkdir .cursor   # Enable Cursor
+mkdir .roo      # Enable Roo Code
 ```
 
 ### Explicit Configuration
@@ -244,11 +252,13 @@ If you prefer to not commit generated files:
 .github/skills/
 .claude/skills/
 .cursor/rules/
+.roo/rules/
 
 # Ignore generated MCP configs (if desired)
 # .vscode/mcp.json
 # .claude/mcp.json
 # .cursor/mcp.json
+# .roo/mcp.json
 ```
 
 ---
@@ -303,7 +313,7 @@ Check the package documentation for required variables.
 **Check agent directories exist:**
 ```bash
 ls -la | grep -E '^\.'
-# Should show .github, .claude, or .cursor
+# Should show .github, .claude, .cursor, or .roo
 ```
 
 **Check the manifest:**

--- a/docs/guides/creating-skill-packages.md
+++ b/docs/guides/creating-skill-packages.md
@@ -50,7 +50,7 @@ Replace the contents of `MyOrg.Skills.Security.csproj`:
     <Authors>Your Name</Authors>
     <Company>Your Organization</Company>
     <Description>Security best practices skills for AI assistants</Description>
-    <PackageTags>ai;skills;security;copilot;claude;cursor</PackageTags>
+    <PackageTags>ai;skills;security;copilot;claude;cursor;roo</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/your-org/skills-security</PackageProjectUrl>
     <RepositoryUrl>https://github.com/your-org/skills-security</RepositoryUrl>

--- a/docs/guides/mcp-server-configuration.md
+++ b/docs/guides/mcp-server-configuration.md
@@ -375,6 +375,19 @@ Imprint adapts the MCP format for each agent:
 }
 ```
 
+### Roo Code
+
+**Location:** `.roo/mcp.json`
+**Root key:** `mcpServers`
+
+```json
+{
+  "mcpServers": {
+    "my-server": { ... }
+  }
+}
+```
+
 You write one fragment with `servers`, and Imprint handles the translation.
 
 ---
@@ -393,6 +406,7 @@ dotnet build
 cat .vscode/mcp.json   # Copilot
 cat .claude/mcp.json   # Claude
 cat .cursor/mcp.json   # Cursor
+cat .roo/mcp.json     # Roo Code
 ```
 
 ### Step 3: Verify Server Starts

--- a/docs/guides/publishing-packages.md
+++ b/docs/guides/publishing-packages.md
@@ -36,7 +36,7 @@ Ensure your `.csproj` has complete metadata:
   <Authors>Your Name</Authors>
   <Company>Your Organization</Company>
   <Description>Security best practices skills for AI assistants</Description>
-  <PackageTags>ai;skills;security;copilot;claude;cursor;imprint</PackageTags>
+  <PackageTags>ai;skills;security;copilot;claude;cursor;roo;imprint</PackageTags>
   <PackageLicenseExpression>MIT</PackageLicenseExpression>
   <PackageProjectUrl>https://github.com/your-org/skills-security</PackageProjectUrl>
   <RepositoryUrl>https://github.com/your-org/skills-security</RepositoryUrl>
@@ -315,6 +315,7 @@ Use relevant tags for discoverability:
 - `copilot`
 - `claude`
 - `cursor`
+- `roo`
 - `imprint`
 - Domain-specific tags (`security`, `azure`, etc.)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Home
 nav_order: 1
-description: "Zakira.Imprint - Distribute AI Skills via NuGet packages for GitHub Copilot, Claude, Cursor, and other AI assistants."
+description: "Zakira.Imprint - Distribute AI Skills via NuGet packages for GitHub Copilot, Claude, Cursor, Roo Code, and other AI assistants."
 permalink: /
 ---
 
@@ -13,7 +13,7 @@ permalink: /
 # Zakira.Imprint
 {: .fs-9 }
 
-Distribute AI Skills via NuGet packages. Ship SKILL.md files for GitHub Copilot, Claude, Cursor, and other AI assistants as easily as shipping a library.
+Distribute AI Skills via NuGet packages. Ship SKILL.md files for GitHub Copilot, Claude, Cursor, Roo Code, and other AI assistants as easily as shipping a library.
 {: .fs-6 .fw-300 }
 
 [Get Started]({{ site.baseurl }}/getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
@@ -35,7 +35,7 @@ Distribute AI Skills via NuGet packages. Ship SKILL.md files for GitHub Copilot,
 ```
 dotnet add package Contoso.Skills.AzureSecurity
 dotnet build
-# Skills are now available in GitHub Copilot, Claude, and Cursor!
+# Skills are now available in GitHub Copilot, Claude, Cursor, and Roo Code!
 ```
 
 ## Key Features
@@ -49,6 +49,7 @@ Imprint automatically detects and targets multiple AI assistants simultaneously:
 | GitHub Copilot | `.github/skills/` | `.vscode/mcp.json` |
 | Claude | `.claude/skills/` | `.claude/mcp.json` |
 | Cursor | `.cursor/rules/` | `.cursor/mcp.json` |
+| Roo Code | `.roo/rules/` | `.roo/mcp.json` |
 
 ### Zero Configuration
 
@@ -157,6 +158,7 @@ After build, the skill is available at:
 - `.github/skills/security/SKILL.md` (Copilot)
 - `.claude/skills/security/SKILL.md` (Claude)
 - `.cursor/rules/security/SKILL.md` (Cursor)
+- `.roo/rules/security/SKILL.md` (Roo Code)
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -132,6 +132,7 @@ After installing a skill package and building:
    ls .github/skills/   # Copilot
    ls .claude/skills/   # Claude
    ls .cursor/rules/    # Cursor
+   ls .roo/rules/       # Roo Code
    ```
 
 2. Check the manifest:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -354,7 +354,7 @@ Resolves the final list of target agents using priority:
 public static List<string> DetectAgents(string projectDirectory)
 ```
 
-Scans for agent directories (`.github`, `.claude`, `.cursor`) and returns detected agents.
+Scans for agent directories (`.github`, `.claude`, `.cursor`, `.roo`) and returns detected agents.
 
 #### GetSkillsPath
 
@@ -378,7 +378,7 @@ Returns the absolute MCP config file path for an agent.
 public static string GetMcpRootKey(string agentName)
 ```
 
-Returns the JSON root key for MCP servers (`"servers"` for VS Code, `"mcpServers"` for Claude/Cursor).
+Returns the JSON root key for MCP servers (`"servers"` for VS Code, `"mcpServers"` for Claude/Cursor/Roo Code).
 
 ### KnownAgents Dictionary
 
@@ -392,10 +392,10 @@ Contains definitions for known agents with their directory conventions.
 
 ```csharp
 public record AgentDefinition(
-    string Name,           // "copilot", "claude", "cursor"
-    string DetectionDir,   // ".github", ".claude", ".cursor"
-    string SkillsSubPath,  // ".github/skills", ".claude/skills", ".cursor/rules"
-    string McpSubPath,     // ".vscode", ".claude", ".cursor"
+    string Name,           // "copilot", "claude", "cursor", "roo"
+    string DetectionDir,   // ".github", ".claude", ".cursor", ".roo"
+    string SkillsSubPath,  // ".github/skills", ".claude/skills", ".cursor/rules", ".roo/rules"
+    string McpSubPath,     // ".vscode", ".claude", ".cursor", ".roo"
     string McpFileName,    // "mcp.json"
     string McpRootKey      // "servers" or "mcpServers"
 );

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -43,14 +43,16 @@ Zakira.Imprint operates in two distinct phases:
 │  │ Package     │───▶│ ImprintCopyContent   │───▶│ .github/skills/       │   │
 │  │ .targets    │    │ MSBuild Task         │    │ .claude/skills/       │   │
 │  │ (ImprintCon-│    └──────────────────────┘    │ .cursor/rules/        │   │
-│  │ tent items) │                                └───────────────────────┘   │
+│  │ tent items) │                                │ .roo/rules/           │   │
+│  └─────────────┘                                └───────────────────────┘   │
 │  └─────────────┘                                                            │
 │                                                                             │
 │  ┌─────────────┐    ┌──────────────────────┐    ┌───────────────────────┐   │
 │  │ Package     │───▶│ ImprintMergeMcpServers│───▶│ .vscode/mcp.json      │   │
 │  │ MCP frags   │    │ MSBuild Task         │    │ .claude/mcp.json      │   │
 │  │ (ImprintMcp-│    └──────────────────────┘    │ .cursor/mcp.json      │   │
-│  │ Fragment)   │                                └───────────────────────┘   │
+│  │ Fragment)   │                                │ .roo/mcp.json         │   │
+│  └─────────────┘                                └───────────────────────┘   │
 │  └─────────────┘                                                            │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -109,7 +111,7 @@ Before copying files, Imprint determines which AI agents to target.
 
 **Resolution order:**
 1. **Explicit setting:** `<ImprintTargetAgents>copilot;claude</ImprintTargetAgents>`
-2. **Auto-detection:** Scans for `.github/`, `.claude/`, `.cursor/` directories
+2. **Auto-detection:** Scans for `.github/`, `.claude/`, `.cursor/`, `.roo/` directories
 3. **Fallback:** Uses `<ImprintDefaultAgents>` (default: `copilot`)
 
 **Known agents:**
@@ -119,6 +121,7 @@ Before copying files, Imprint determines which AI agents to target.
 | copilot | `.github` | `.github/skills/` | `.vscode/mcp.json` | `servers` |
 | claude | `.claude` | `.claude/skills/` | `.claude/mcp.json` | `mcpServers` |
 | cursor | `.cursor` | `.cursor/rules/` | `.cursor/mcp.json` | `mcpServers` |
+| roo | `.roo` | `.roo/rules/` | `.roo/mcp.json` | `mcpServers` |
 
 ### 2. Skill File Copying (`ImprintCopyContent`)
 
@@ -170,7 +173,7 @@ Solution: Use `<ImprintPrefix>` on one of the packages.
 
 **Agent-specific root keys:**
 - VS Code/Copilot: `"servers"` (matches VS Code MCP extension)
-- Claude/Cursor: `"mcpServers"` (matches their native format)
+- Claude/Cursor/Roo Code: `"mcpServers"` (matches their native format)
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,6 +29,7 @@ When enabled, Imprint scans the project directory for existing agent folders:
 - `.github/` → Copilot detected
 - `.claude/` → Claude detected  
 - `.cursor/` → Cursor detected
+- `.roo/` → Roo Code detected
 
 ```xml
 <PropertyGroup>
@@ -47,7 +48,7 @@ Explicitly specifies which agents to target. When set, disables auto-detection.
 | **Type** | String (semicolon-separated) |
 | **Default** | *(empty)* |
 | **Scope** | Consumer projects |
-| **Values** | `copilot`, `claude`, `cursor` |
+| **Values** | `copilot`, `claude`, `cursor`, `roo` |
 
 ```xml
 <PropertyGroup>
@@ -71,7 +72,7 @@ Fallback agents when auto-detection finds no existing agent directories.
 ```xml
 <PropertyGroup>
   <!-- Default to all agents if none detected -->
-  <ImprintDefaultAgents>copilot;claude;cursor</ImprintDefaultAgents>
+  <ImprintDefaultAgents>copilot;claude;cursor;roo</ImprintDefaultAgents>
 </PropertyGroup>
 ```
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -48,3 +48,4 @@ Detailed documentation for MSBuild tasks and item groups.
 | Copilot | `.github/skills/` | `.vscode/mcp.json` |
 | Claude | `.claude/skills/` | `.claude/mcp.json` |
 | Cursor | `.cursor/rules/` | `.cursor/mcp.json` |
+| Roo Code | `.roo/rules/` | `.roo/mcp.json` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,6 +137,7 @@ dotnet nuget locals all --list
 | GitHub Copilot | `.github/skills/{package-folder}/SKILL.md` |
 | Claude | `.claude/skills/{package-folder}/SKILL.md` |
 | Cursor | `.cursor/rules/{package-folder}/*.mdc` |
+| Roo Code | `.roo/rules/{package-folder}/*.mdc` |
 
 **Possible causes:**
 
@@ -149,7 +150,7 @@ dotnet nuget locals all --list
    ```
 
 2. **Wrong agent targeted:**
-   - The skill folder varies by agent (`.github/skills/`, `.claude/skills/`, `.cursor/rules/`)
+   - The skill folder varies by agent (`.github/skills/`, `.claude/skills/`, `.cursor/rules/`, `.roo/rules/`)
    - Verify `ImprintTargetAgents` is set correctly
 
 ### Manifest Conflicts
@@ -183,6 +184,7 @@ dotnet restore
 | Copilot (VS Code) | `.vscode/mcp.json` | `servers` |
 | Claude | `.claude/mcp.json` | `mcpServers` |
 | Cursor | `.cursor/mcp.json` | `mcpServers` |
+| Roo Code | `.roo/mcp.json` | `mcpServers` |
 
 **Possible causes:**
 
@@ -210,7 +212,7 @@ dotnet restore
    ```xml
    <!-- Ensure the agent is included -->
    <PropertyGroup>
-     <ImprintTargetAgents>copilot;claude;cursor</ImprintTargetAgents>
+     <ImprintTargetAgents>copilot;claude;cursor;roo</ImprintTargetAgents>
    </PropertyGroup>
    ```
 
@@ -277,6 +279,16 @@ dotnet restore
 1. Verify `.mdc` files exist in `.cursor/rules/`
 2. Restart Cursor IDE
 3. Check Cursor's rules panel for the loaded rules
+
+### Roo Code Rules Not Applied
+
+**Symptom:** Roo Code doesn't apply the deployed rules.
+
+**Checklist:**
+1. Verify rule files exist in `.roo/rules/`
+2. Check `.roo/mcp.json` for MCP configuration
+3. Restart Roo Code
+4. Verify MCP server is running (if applicable)
 
 ---
 
@@ -418,6 +430,9 @@ cat .claude/mcp.json | jq .
 
 # Cursor MCP config
 cat .cursor/mcp.json | jq .
+
+# Roo Code MCP config
+cat .roo/mcp.json | jq .
 ```
 
 ---

--- a/src/Zakira.Imprint.Sdk/AgentConfig.cs
+++ b/src/Zakira.Imprint.Sdk/AgentConfig.cs
@@ -38,6 +38,13 @@ namespace Zakira.Imprint.Sdk
                     McpSubPath: ".cursor",
                     McpFileName: "mcp.json",
                     McpRootKey: "mcpServers"),
+                ["roo"] = new AgentDefinition(
+                    Name: "roo",
+                    DetectionDir: ".roo",
+                    SkillsSubPath: ".roo" + Path.DirectorySeparatorChar + "rules",
+                    McpSubPath: ".roo",
+                    McpFileName: "mcp.json",
+                    McpRootKey: "mcpServers"),
             };
 
         /// <summary>

--- a/tests/Zakira.Imprint.Sdk.Tests/AgentConfigTests.cs
+++ b/tests/Zakira.Imprint.Sdk.Tests/AgentConfigTests.cs
@@ -121,16 +121,26 @@ public class AgentConfigTests : IDisposable
     }
 
     [Fact]
+    public void DetectAgents_FindsRoo()
+    {
+        Directory.CreateDirectory(Path.Combine(_testDir, ".roo"));
+        var detected = AgentConfig.DetectAgents(_testDir);
+        Assert.Contains("roo", detected);
+    }
+
+    [Fact]
     public void DetectAgents_FindsMultiple()
     {
         Directory.CreateDirectory(Path.Combine(_testDir, ".github"));
         Directory.CreateDirectory(Path.Combine(_testDir, ".claude"));
         Directory.CreateDirectory(Path.Combine(_testDir, ".cursor"));
+        Directory.CreateDirectory(Path.Combine(_testDir, ".roo"));
         var detected = AgentConfig.DetectAgents(_testDir);
-        Assert.Equal(3, detected.Count);
+        Assert.Equal(4, detected.Count);
         Assert.Contains("copilot", detected);
         Assert.Contains("claude", detected);
         Assert.Contains("cursor", detected);
+        Assert.Contains("roo", detected);
     }
 
     [Fact]
@@ -215,6 +225,13 @@ public class AgentConfigTests : IDisposable
     }
 
     [Fact]
+    public void GetSkillsPath_Roo()
+    {
+        var path = AgentConfig.GetSkillsPath(_testDir, "roo");
+        Assert.Equal(Path.Combine(_testDir, ".roo", "rules"), path);
+    }
+
+    [Fact]
     public void GetSkillsPath_UnknownAgent_UsesConvention()
     {
         var path = AgentConfig.GetSkillsPath(_testDir, "windsurf");
@@ -242,6 +259,13 @@ public class AgentConfigTests : IDisposable
     {
         var path = AgentConfig.GetMcpPath(_testDir, "cursor");
         Assert.Equal(Path.Combine(_testDir, ".cursor", "mcp.json"), path);
+    }
+
+    [Fact]
+    public void GetMcpPath_Roo()
+    {
+        var path = AgentConfig.GetMcpPath(_testDir, "roo");
+        Assert.Equal(Path.Combine(_testDir, ".roo", "mcp.json"), path);
     }
 
     [Fact]
@@ -275,6 +299,13 @@ public class AgentConfigTests : IDisposable
     }
 
     [Fact]
+    public void GetMcpDirectory_Roo()
+    {
+        var dir = AgentConfig.GetMcpDirectory(_testDir, "roo");
+        Assert.Equal(Path.Combine(_testDir, ".roo"), dir);
+    }
+
+    [Fact]
     public void GetMcpDirectory_UnknownAgent_UsesConvention()
     {
         var dir = AgentConfig.GetMcpDirectory(_testDir, "windsurf");
@@ -284,12 +315,13 @@ public class AgentConfigTests : IDisposable
     // ── KnownAgents ─────────────────────────────────────────────────
 
     [Fact]
-    public void KnownAgents_ContainsThreeAgents()
+    public void KnownAgents_ContainsFourAgents()
     {
-        Assert.Equal(3, AgentConfig.KnownAgents.Count);
+        Assert.Equal(4, AgentConfig.KnownAgents.Count);
         Assert.True(AgentConfig.KnownAgents.ContainsKey("copilot"));
         Assert.True(AgentConfig.KnownAgents.ContainsKey("claude"));
         Assert.True(AgentConfig.KnownAgents.ContainsKey("cursor"));
+        Assert.True(AgentConfig.KnownAgents.ContainsKey("roo"));
     }
 
     [Fact]
@@ -298,6 +330,7 @@ public class AgentConfigTests : IDisposable
         Assert.True(AgentConfig.KnownAgents.ContainsKey("Copilot"));
         Assert.True(AgentConfig.KnownAgents.ContainsKey("CLAUDE"));
         Assert.True(AgentConfig.KnownAgents.ContainsKey("cUrSoR"));
+        Assert.True(AgentConfig.KnownAgents.ContainsKey("ROO"));
     }
 
     [Fact]
@@ -331,5 +364,17 @@ public class AgentConfigTests : IDisposable
         Assert.Equal(".cursor" + Path.DirectorySeparatorChar + "rules", def.SkillsSubPath);
         Assert.Equal(".cursor", def.McpSubPath);
         Assert.Equal("mcp.json", def.McpFileName);
+    }
+
+    [Fact]
+    public void KnownAgents_RooDefinition()
+    {
+        var def = AgentConfig.KnownAgents["roo"];
+        Assert.Equal("roo", def.Name);
+        Assert.Equal(".roo", def.DetectionDir);
+        Assert.Equal(".roo" + Path.DirectorySeparatorChar + "rules", def.SkillsSubPath);
+        Assert.Equal(".roo", def.McpSubPath);
+        Assert.Equal("mcp.json", def.McpFileName);
+        Assert.Equal("mcpServers", def.McpRootKey);
     }
 }


### PR DESCRIPTION
Add roo as a known agent alongside copilot, claude, and cursor:
- Add roo agent definition in AgentConfig.cs with .roo detection, .roo/rules/ skills path, .roo/mcp.json config, and mcpServers root key
- Add tests for roo agent detection, skills path, MCP path, and definition
- Update all documentation to include Roo Code in agent tables, detection directories, path examples, troubleshooting, and MCP configuration guides