### PR TITLE
fix: add multi-targeting support with cross-targeting imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ When you run `dotnet pack` on your Imprint package:
 
 1. **Generate Targets** (`Imprint_GenerateTargetsFile`): The SDK reads all `<Imprint>` items from your `.csproj` and generates a `.targets` file at `obj/{Configuration}/{TFM}/Imprint/{PackageId}.targets`. This file declares `ImprintContent` and `ImprintMcpFragment` items that consumers will use.
 
-2. **Include Content** (`Imprint_IncludeContentInPackage`): The SDK adds the generated `.targets` file to both `build/` and `buildTransitive/` package paths, and includes all content files (skills, MCP fragments) in the `content/` folder.
+2. **Include Content + Cross-Targeting Import** (`Imprint_IncludeContentInPackage`): The SDK adds the generated `.targets` file to both `build/` and `buildTransitive/` package paths, includes all content files (skills, MCP fragments) in the `content/` folder, and for multi-targeted package projects (`<TargetFrameworks>...`) imports via `buildMultiTargeting/` in the outer pack build so Imprint pack targets can run before `_GetPackageFiles`.
 
 3. **NuGet Pack**: The package is created with all necessary files — no manual `.targets` authoring required.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,6 +39,11 @@ Common issues and solutions when working with Zakira.Imprint.
    - Check if your skill files match patterns in `.gitignore`
    - The SDK respects standard ignore patterns
 
+4. **Using an SDK version without cross-targeting pack imports:**
+   - In multi-targeted package projects (`<TargetFrameworks>...`), NuGet pack runs key collection targets in an outer cross-targeting build.
+   - If Imprint targets are not imported in that outer build, generated `build/*.targets` and `content/skills/*` entries are omitted.
+   - Upgrade to a Zakira.Imprint.Sdk version that includes `buildMultiTargeting` assets.
+
 **Diagnosis:**
 ```bash
 # Build with detailed logging

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.417",
+    "rollForward": "latestFeature"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "8.0.417",
-    "rollForward": "latestFeature"
-  }
-}

--- a/src/Zakira.Imprint.Sdk/Zakira.Imprint.Sdk.csproj
+++ b/src/Zakira.Imprint.Sdk/Zakira.Imprint.Sdk.csproj
@@ -42,6 +42,8 @@
     <None Include="build\Zakira.Imprint.Sdk.targets" Pack="true" PackagePath="build" />
     <None Include="buildTransitive\Zakira.Imprint.Sdk.props" Pack="true" PackagePath="buildTransitive" />
     <None Include="buildTransitive\Zakira.Imprint.Sdk.targets" Pack="true" PackagePath="buildTransitive" />
+    <None Include="buildMultiTargeting\Zakira.Imprint.Sdk.props" Pack="true" PackagePath="buildMultiTargeting" />
+    <None Include="buildMultiTargeting\Zakira.Imprint.Sdk.targets" Pack="true" PackagePath="buildMultiTargeting" />
 
     <!-- Include package README -->
     <None Include="..\..\assets\nuget\README.md" Pack="true" PackagePath="" />

--- a/src/Zakira.Imprint.Sdk/buildMultiTargeting/Zakira.Imprint.Sdk.props
+++ b/src/Zakira.Imprint.Sdk/buildMultiTargeting/Zakira.Imprint.Sdk.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Import the main props from build/ folder for cross-targeting (outer) builds -->
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Zakira.Imprint.Sdk.props" />
+</Project>

--- a/src/Zakira.Imprint.Sdk/buildMultiTargeting/Zakira.Imprint.Sdk.targets
+++ b/src/Zakira.Imprint.Sdk/buildMultiTargeting/Zakira.Imprint.Sdk.targets
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Import the main targets from build/ folder for cross-targeting (outer) builds -->
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Zakira.Imprint.Sdk.targets" />
+</Project>


### PR DESCRIPTION
## Summary
This PR fixes an issue where Imprint content was not included when packing multi-targeted projects (projects using TargetFrameworks).

In those cases, Imprint pack-time targets were not running in the outer cross-targeting pack build, so generated targets and content files were missing from the final .nupkg.

## Root cause
Imprint pack logic (generate targets + include content) existed in build/ and buildTransitive/.
For multi-targeted dotnet pack, NuGet/MSBuild runs key pack collection in an outer cross-targeting context.
Without buildMultiTargeting imports, Imprint pack targets were not loaded there.
## Changes
Added buildMultiTargeting support to Zakira.Imprint.Sdk:
[Zakira.Imprint.Sdk.props](vscode-file://vscode-app/c:/Users/matthew.davidson/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[Zakira.Imprint.Sdk.targets](vscode-file://vscode-app/c:/Users/matthew.davidson/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated SDK packing to include both files under buildMultiTargeting/ in the SDK .nupkg.
Updated docs:
[README.md](vscode-file://vscode-app/c:/Users/matthew.davidson/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) pack-time flow now documents cross-targeting import behavior.
[troubleshooting.md](vscode-file://vscode-app/c:/Users/matthew.davidson/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) includes the multi-target packaging symptom/cause.
## Validation
Packed the patched SDK locally and confirmed the .nupkg includes buildMultiTargeting assets.
Reproduced the consumer scenario with a multi-target package project and validated packaging behavior against the patched SDK setup.
## Impact
Multi-targeted Imprint package authors now get generated build/ + buildTransitive/ targets and content/ files included consistently during dotnet pack.
Single-target behavior remains unchanged.