### PR TITLE
fix: implement safe file copy to handle parallel builds and avoid con…

### DIFF
--- a/src/Zakira.Imprint.Sdk/ImprintCopyContent.cs
+++ b/src/Zakira.Imprint.Sdk/ImprintCopyContent.cs
@@ -155,7 +155,7 @@ namespace Zakira.Imprint.Sdk
                                 Directory.CreateDirectory(destDir);
                             }
 
-                            File.Copy(sourceFile, destFile, overwrite: true);
+                            CopyFileSafe(sourceFile, destFile);
                             manifestPackages[packageId][agent].Add(destFile);
 
                             // Track for gitignore
@@ -775,6 +775,41 @@ namespace Zakira.Imprint.Sdk
             {
                 // Ignore - directory might be in use or protected
             }
+        }
+
+        /// <summary>
+        /// Copies a file to the destination, skipping if already identical.
+        /// Handles IOException gracefully for parallel builds where multiple projects
+        /// reference the same package and race to write the same destination file.
+        /// </summary>
+        private static void CopyFileSafe(string sourceFile, string destFile)
+        {
+            if (File.Exists(destFile) && FilesAreIdentical(sourceFile, destFile))
+            {
+                return; // Already up-to-date, skip
+            }
+
+            try
+            {
+                File.Copy(sourceFile, destFile, overwrite: true);
+            }
+            catch (IOException)
+            {
+                // Another parallel build process may have already copied an identical file.
+                // Verify the destination matches the source before swallowing the error.
+                if (!File.Exists(destFile) || !FilesAreIdentical(sourceFile, destFile))
+                {
+                    throw;
+                }
+            }
+        }
+
+        private static bool FilesAreIdentical(string a, string b)
+        {
+            var infoA = new FileInfo(a);
+            var infoB = new FileInfo(b);
+            return infoA.Length == infoB.Length &&
+                   infoA.LastWriteTimeUtc == infoB.LastWriteTimeUtc;
         }
 
         private void EnsureImprintGitignore(string imprintDir)


### PR DESCRIPTION
## Proposed fix

1. Skip-if-identical: Before copying, check whether the destination file already matches the source (by size + last-write timestamp). Skip the copy if so — this eliminates the race window entirely on incremental builds.
2. Graceful IOException handling: If a copy does race and throws IOException, verify the destination now matches the source. If it does, treat it as success (another process already did the work). If it doesn't, re-throw.

This fixes issue #8 